### PR TITLE
[refs #23] edit small typo

### DIFF
--- a/site/posts/getting-started.md
+++ b/site/posts/getting-started.md
@@ -29,7 +29,7 @@ _\*Considerate means semantic, accessible mark-up, written for both humans and m
 
 Additional features:
 
-- Seemless JavaScript and SCSS compilation (no build process)
+- Seamless JavaScript and SCSS compilation (no build process)
 - Data-driven navigation
 - Customisable settings including theming
 


### PR DESCRIPTION
fixed the spelling of "seemless" on the Getting Started page. It should have been "seamless"