### PR TITLE
fixed nodejs requirement for netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <br><img src="site/static/screenshot.png" width="500"/>
     <br>
     <p>See a <a href="https://supermaya-demo.netlify.com/">Live Demo</a>.</p>
-    <p><a href="https://app.netlify.com/start/deploy?repository=https://github.com/MadeByMike/supermaya">Deploy Supermaya on it's own</a></p>
+    <p><a href="https://app.netlify.com/start/deploy?repository=https://github.com/httpsterio/supermaya">Deploy Supermaya on it's own</a></p>
     <p><a href="https://heroku.com/deploy?template=https://github.com/keystonejs/keystone-jamstack-plus">Deploy Supermaya with Keystone</a> to allow user generated content. <br>(following instructions during installation to connect the API).</p>
     <br>
     <br>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  environment = { NODE_VERSION = "12.0.x" }
   command = "npm run build"
   publish = "dist"
 [template.environment]


### PR DESCRIPTION
Commit 553edb6191564311eac166e45b0e8c653ba0a150 breaks Netlify-deployments. Node 12.0.x has been available on Netlify for some time, but it still defaults to 10.x.x, so it can't satisfy the required bumped version. By adding the enviroment variable in the toml-file we can specify the Node version on Netlify's side.

Another fix would be to create a .node-versions or .nvmrc which would also work on Netlify's end (I think?)