### PR TITLE
added nodejs enviroment variable into the toml-file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  environment = { NODE_VERSION = "12.0.0" }
   command = "npm run build"
   publish = "dist"
 [template.environment]


### PR DESCRIPTION
My previous PR was bad, I tried to use Semver when in fact it's just an enviroment variable and we need to be explicit in the requirements.

Anyways, without specifying a Node.js-version for Netlify to use, it'll default to 10.2 which is <11. 

I couldn't find any comprehensive list of Node.js versions available on Netlify so in case this creates compatibility issues, another version needs to be selected.