### PR TITLE
Fix overflow issue on posts-collection

### DIFF
--- a/site/src/scss/_partials/post-list.scss
+++ b/site/src/scss/_partials/post-list.scss
@@ -1,5 +1,5 @@
 .l-post-list > * {
-  width: 60ch;
+  max-width: 60ch;
 }
 
 .l-post-list > * + * {


### PR DESCRIPTION
60ch might overflow on smaller screens (as see on the Supermaya demo page). Adding a max-width to it fixes it and there's no horizontal scrolls after that.